### PR TITLE
:bug: fix #1

### DIFF
--- a/shellScript/show-participants-data.sh
+++ b/shellScript/show-participants-data.sh
@@ -2,8 +2,6 @@
 
 while read YEAR MONTH DAY HOUR MINUTE SECOND NANOSECOND
 do
-#  echo "[year]${YEAR} [month]${MONTH} [day]${DAY} [hour]${HOUR} [minute]${MINUTE} [second]${SECOND} [nanosecond]${NANOSECOND}"
-
   printf '{
     "year": "%s",
     "month": "%s",
@@ -22,5 +20,5 @@ do
 }
 '
 
-done <<< $(date +"%Y %m %d %H %m %S %N")
+done <<< $(date +"%Y %m %d %H %m %S")
 


### PR DESCRIPTION
#1 を修正した。

`date` コマンドのナノセカンド表示をやめた。
